### PR TITLE
fix cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,7 @@ set(LIBMODBUS_VERSION_MICRO 6)
 configure_file("src/win32/config.h.win32" "src/config.h" COPYONLY)
 configure_file("src/modbus-version.h.in" "src/modbus-version.h" @ONLY)
 
-add_library(libmodbus
-    SHARED
-        ${SOURCES}
-        ${HEADERS}
-        "src/config.h"
-        "src/modbus-version.h")
+add_library(libmodbus SHARED ${SOURCES} ${HEADERS})
 
 target_include_directories(libmodbus
     PUBLIC


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.31/command/configure_file.html:
> A relative path is treated with respect to the value of [CMAKE_CURRENT_BINARY_DIR](https://cmake.org/cmake/help/v3.31/variable/CMAKE_CURRENT_BINARY_DIR.html#variable:CMAKE_CURRENT_BINARY_DIR).

`config.h` and `modbus-version.h"` are not placed in `src/`, but rather in `${CMAKE_CURRENT_BINARY_DIR}/src`, which is covered by `target_include_directories` below